### PR TITLE
docs(github): add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,7 +6,6 @@ assignees: []
 body:
  - type: markdown
    attributes:
-    label: "Report a bug"
     value: |
      Thanks for reporting a bug! Please fiil out the sections below as clearly as possible.
 
@@ -16,7 +15,7 @@ body:
     label: Summary
     description: What is the bug? Keep it short and precise.
     placeholder: Product stock is not updated when calling Update method
-   validatons:
+   validations:
     required: true
 
  - type: textarea


### PR DESCRIPTION
## Description
This PR adds GitHub bug/fix template to standardize how work bugs are reported.

### Key changes
- Added bug template

### Notes / Edge cases
This is a developer-experience improvement only and does not introduce functional changes.

### Checklist
- [ ] I kept the change focused (no unrelated refactors)
- [ ] Tests added/updated (or N/A with reason)
- [ ] Docs updated (or N/A)
- [ ] No secrets or environment-specific overrides committed
