### PR TITLE
(test): add restock warning emission behavior tests

### DIFF
--- a/apps/api/Tests/Inventory/Products/Domain.Tests/ProductRestockWarningTests.cs
+++ b/apps/api/Tests/Inventory/Products/Domain.Tests/ProductRestockWarningTests.cs
@@ -19,7 +19,7 @@ public class ProductRestockWarningTests
     }
 
     [Fact]
-    public void AdjustStock_Raises_Warning_Only_on_Crossing_into_Low_Stock()
+    public void AdjustStock_Raises_Warning_on_Crossing_into_Low_Stock()
     {
         // Arrange
         var product = ProductTestFactory.CreateProduct(stock: 3, threshold: 2);


### PR DESCRIPTION
## Description

This PR adds unit tests documenting when `RestockWarningEvent` is raised across `SetThreshold` and `AdjustStock`.

### Key changes

- Added `ProductRestockWarningTests`

### Notes / Edge cases

It was decided that the duplicate restock warning are not acceptable. They are registered only when there's a transitioning state.

### Checklist

- [x] I kept the change focused (no unrelated refactors)
- [x] Tests added/updated (or N/A with reason)
- [ ] Docs updated (or N/A)
- [x] No secrets or environment-specific overrides committed
