### PR TITLE
fix(github): update pr title regex

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -20,10 +20,10 @@ jobs:
 
       # Format: type(scope): sumary
 
-      REGEX='^(feat|fix|docs|refactor|test|chore|perf|ci)\([a-z0-9-]+|): [a-z0-9].{2,}$'
+      REGEX='^(feat|fix|docs|refactor|test|chore|perf|ci)\([a-z0-9-]+\): [a-z][a-z0-9 ,._-].{2,}$'
 
       if [[ ! "$TITLE" =~ $REGEX ]]; then
-       echo "::error title=Invalid PR title::Exprected: type(scope): summary"
+       echo "::error title=Invalid PR title::'$TITLE' does not match 'type(scope): summary'"
        echo "Check documentation for convention"
        exit 1
       fi


### PR DESCRIPTION
## Description

This PR fixes the pipeline bug where invalid PR titles could pass the validation successfully.

### Key changes

- Fixed error in the regex formatting 
- Added enforcement for lowercase in the regex  

### Notes / Edge cases
N/A

### Checklist

- [x] I kept the change focused (no unrelated refactors)
- [ ] Tests added/updated (or N/A with reason)
- [ ] Docs updated (or N/A)
- [x] No secrets or environment-specific overrides committed
