### PR TITLE
feat(receipt): add open purchase receipt endpoint

### DIFF
--- a/apps/api/Bootstrapper/Api/Program.cs
+++ b/apps/api/Bootstrapper/Api/Program.cs
@@ -5,7 +5,9 @@ using System.Net.Sockets;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddApplicationPart(typeof(InventoryModule).Assembly)
+    .AddApplicationPart(typeof(ReceiptModule).Assembly);
 
 builder.Services
     .AddInventoryModule(builder.Configuration)

--- a/apps/api/Modules/Receipt/Receipt/Api/Contracts/OpenPurchaseReceiptContract.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Contracts/OpenPurchaseReceiptContract.cs
@@ -1,0 +1,5 @@
+﻿namespace Receipt.Api.Contracts;
+
+public record OpenPurchaseReceiptRequest(PurchaseReceiptDto PurchaseReceipt);
+
+public record OpenPurchaseReceiptResponse(Guid Id);

--- a/apps/api/Modules/Receipt/Receipt/Api/Contracts/OpenPurchaseReceiptContract.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Contracts/OpenPurchaseReceiptContract.cs
@@ -1,5 +1,5 @@
 ﻿namespace Receipt.Api.Contracts;
 
-public record OpenPurchaseReceiptRequest(PurchaseReceiptDto PurchaseReceipt);
+public record OpenPurchaseReceiptRequest(DateOnly PurchaseDate, string? Location);
 
 public record OpenPurchaseReceiptResponse(Guid Id);

--- a/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
@@ -1,0 +1,24 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Receipt.Api.Contracts;
+using Receipt.Application.Features.OpenPurchaseReceipt;
+using Shared.Messaging;
+
+namespace Receipt.Api.Controllers;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/receipt/purchase")]
+public class PurchaseReceiptController(IMediator mediator) : ControllerBase
+{
+    [HttpPost]
+    [ProducesResponseType(typeof(OpenPurchaseReceiptResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<OpenPurchaseReceiptResponse>> Create(OpenPurchaseReceiptRequest request, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new OpenPurchaseReceiptCommand(request.PurchaseReceipt), cancellationToken);
+        var response = new OpenPurchaseReceiptResponse(result.Id);
+        return Created($"{response.Id}", response);
+    }
+}

--- a/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
@@ -9,13 +9,13 @@ namespace Receipt.Api.Controllers;
 
 [ApiController]
 [ApiVersion("1.0")]
-[Route("api/v{version:apiVersion}/receipt/purchase")]
+[Route("api/v{version:apiVersion}/receipt/purchase-receipts")]
 public class PurchaseReceiptController(IMediator mediator) : ControllerBase
 {
     [HttpPost]
     [ProducesResponseType(typeof(OpenPurchaseReceiptResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<OpenPurchaseReceiptResponse>> Create(OpenPurchaseReceiptRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult<OpenPurchaseReceiptResponse>> Create([FromBody] OpenPurchaseReceiptRequest request, CancellationToken cancellationToken)
     {
         var result = await mediator.Send(new OpenPurchaseReceiptCommand(request.PurchaseDate, request.Location), cancellationToken);
         var response = new OpenPurchaseReceiptResponse(result.Id);

--- a/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
@@ -17,7 +17,7 @@ public class PurchaseReceiptController(IMediator mediator) : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<OpenPurchaseReceiptResponse>> Create(OpenPurchaseReceiptRequest request, CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new OpenPurchaseReceiptCommand(request.PurchaseReceipt), cancellationToken);
+        var result = await mediator.Send(new OpenPurchaseReceiptCommand(request.PurchaseDate, request.Location), cancellationToken);
         var response = new OpenPurchaseReceiptResponse(result.Id);
         return Created($"{response.Id}", response);
     }

--- a/apps/api/Modules/Receipt/Receipt/Application/Dtos/PurchaseReceiptDto.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Dtos/PurchaseReceiptDto.cs
@@ -1,0 +1,5 @@
+﻿namespace Receipt.Application.Dtos;
+
+public record PurchaseReceiptDto(
+    DateOnly PurchaseDate,
+    string? Location);

--- a/apps/api/Modules/Receipt/Receipt/Application/Dtos/PurchaseReceiptDto.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Dtos/PurchaseReceiptDto.cs
@@ -1,5 +1,0 @@
-﻿namespace Receipt.Application.Dtos;
-
-public record PurchaseReceiptDto(
-    DateOnly PurchaseDate,
-    string? Location);

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptCommand.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace Receipt.Application.Features.OpenPurchaseReceipt;
+
+public record OpenPurchaseReceiptCommand(PurchaseReceiptDto PurchaseReceipt)
+    : ICommand<OpenPurchaseReceiptResult>;
+
+public record OpenPurchaseReceiptResult(Guid Id);

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptCommand.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptCommand.cs
@@ -1,6 +1,6 @@
 ﻿namespace Receipt.Application.Features.OpenPurchaseReceipt;
 
-public record OpenPurchaseReceiptCommand(PurchaseReceiptDto PurchaseReceipt)
+public record OpenPurchaseReceiptCommand(DateOnly PurchaseDate, string? Location)
     : ICommand<OpenPurchaseReceiptResult>;
 
 public record OpenPurchaseReceiptResult(Guid Id);

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptHandler.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptHandler.cs
@@ -4,18 +4,13 @@ internal class OpenPurchaseReceiptHandler(ReceiptDbContext dbContext) : ICommand
 {
     public async Task<OpenPurchaseReceiptResult> Handle(OpenPurchaseReceiptCommand request, CancellationToken cancellationToken)
     {
-        PurchaseReceipt purchaseReceipt = CreateOpenReceipt(request);
+        var purchaseReceipt = PurchaseReceipt.Open(
+            request.PurchaseDate,
+            request.Location);
 
         await dbContext.PurchaseReceipts.AddAsync(purchaseReceipt, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return new OpenPurchaseReceiptResult(purchaseReceipt.Id);
-    }
-
-    private static PurchaseReceipt CreateOpenReceipt(OpenPurchaseReceiptCommand request)
-    {
-        return PurchaseReceipt.Open(
-            request.PurchaseDate,
-            request.Location);
     }
 }

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptHandler.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptHandler.cs
@@ -1,0 +1,21 @@
+﻿namespace Receipt.Application.Features.OpenPurchaseReceipt;
+
+internal class OpenPurchaseReceiptHandler(ReceiptDbContext dbContext) : ICommandHandler<OpenPurchaseReceiptCommand, OpenPurchaseReceiptResult>
+{
+    public async Task<OpenPurchaseReceiptResult> Handle(OpenPurchaseReceiptCommand request, CancellationToken cancellationToken)
+    {
+        PurchaseReceipt purchaseReceipt = CreateOpenReceipt(request.PurchaseReceipt);
+
+        await dbContext.PurchaseReceipts.AddAsync(purchaseReceipt, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new OpenPurchaseReceiptResult(purchaseReceipt.Id);
+    }
+
+    private static PurchaseReceipt CreateOpenReceipt(PurchaseReceiptDto request)
+    {
+        return PurchaseReceipt.Open(
+            request.PurchaseDate,
+            request.Location);
+    }
+}

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptHandler.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptHandler.cs
@@ -4,7 +4,7 @@ internal class OpenPurchaseReceiptHandler(ReceiptDbContext dbContext) : ICommand
 {
     public async Task<OpenPurchaseReceiptResult> Handle(OpenPurchaseReceiptCommand request, CancellationToken cancellationToken)
     {
-        PurchaseReceipt purchaseReceipt = CreateOpenReceipt(request.PurchaseReceipt);
+        PurchaseReceipt purchaseReceipt = CreateOpenReceipt(request);
 
         await dbContext.PurchaseReceipts.AddAsync(purchaseReceipt, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
@@ -12,7 +12,7 @@ internal class OpenPurchaseReceiptHandler(ReceiptDbContext dbContext) : ICommand
         return new OpenPurchaseReceiptResult(purchaseReceipt.Id);
     }
 
-    private static PurchaseReceipt CreateOpenReceipt(PurchaseReceiptDto request)
+    private static PurchaseReceipt CreateOpenReceipt(OpenPurchaseReceiptCommand request)
     {
         return PurchaseReceipt.Open(
             request.PurchaseDate,

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptValidator.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptValidator.cs
@@ -1,0 +1,17 @@
+﻿using Shared.Abstractions.Time;
+
+namespace Receipt.Application.Features.OpenPurchaseReceipt;
+
+internal class OpenPurchaseReceiptValidator(IClock clock) : IRequestValidator<OpenPurchaseReceiptCommand>
+{
+    private readonly IClock _clock = clock;
+    public IReadOnlyCollection<ValidationFailure> Validate(OpenPurchaseReceiptCommand request)
+    {
+        List<ValidationFailure> failures = [];
+
+        if (request.PurchaseReceipt.PurchaseDate > DateOnly.FromDateTime(_clock.UtcNow))
+            failures.Add(new ValidationFailure(nameof(request.PurchaseReceipt.PurchaseDate), "Purchase date cannot be in the future."));
+
+        return failures;
+    }
+}

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptValidator.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptValidator.cs
@@ -9,8 +9,8 @@ internal class OpenPurchaseReceiptValidator(IClock clock) : IRequestValidator<Op
     {
         List<ValidationFailure> failures = [];
 
-        if (request.PurchaseReceipt.PurchaseDate > DateOnly.FromDateTime(_clock.UtcNow))
-            failures.Add(new ValidationFailure(nameof(request.PurchaseReceipt.PurchaseDate), "Purchase date cannot be in the future."));
+        if (request.PurchaseDate > DateOnly.FromDateTime(_clock.UtcNow))
+            failures.Add(new ValidationFailure(nameof(request.PurchaseDate), "Purchase date cannot be in the future."));
 
         return failures;
     }

--- a/apps/api/Modules/Receipt/Receipt/GlobalUsings.cs
+++ b/apps/api/Modules/Receipt/Receipt/GlobalUsings.cs
@@ -6,6 +6,5 @@ global using Shared.CQRS;
 global using Shared.DDD;
 global using Shared.Validation;
 
-global using Receipt.Application.Dtos;
 global using Receipt.Domain.Models;
 global using Receipt.Infrastructure;

--- a/apps/api/Modules/Receipt/Receipt/GlobalUsings.cs
+++ b/apps/api/Modules/Receipt/Receipt/GlobalUsings.cs
@@ -2,7 +2,10 @@
 global using Microsoft.EntityFrameworkCore.Metadata.Builders;
 global using System.Reflection;
 
+global using Shared.CQRS;
 global using Shared.DDD;
+global using Shared.Validation;
 
+global using Receipt.Application.Dtos;
 global using Receipt.Domain.Models;
 global using Receipt.Infrastructure;

--- a/apps/api/Modules/Receipt/Receipt/ReceiptModule.cs
+++ b/apps/api/Modules/Receipt/Receipt/ReceiptModule.cs
@@ -2,8 +2,10 @@
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Receipt.Application.Features.OpenPurchaseReceipt;
 using Shared.Data;
 using Shared.Data.Interceptors;
+using Shared.Messaging;
 
 namespace Receipt;
 
@@ -16,6 +18,9 @@ public static class ReceiptModule
         // Api Endpoint services
 
         // Application Use Case services
+        services.AddScoped<IRequestValidator<OpenPurchaseReceiptCommand>, OpenPurchaseReceiptValidator>();
+
+        services.AddScoped<IRequestHandler<OpenPurchaseReceiptCommand, OpenPurchaseReceiptResult>, OpenPurchaseReceiptHandler>();
 
         // Data - Infrastructure services
         var connectionString = configuration.GetConnectionString("Default");


### PR DESCRIPTION
## Description
this PR adds open receipt that can be created and persisted through the Receipt API.

### Key changes
- Added `OpenPurchaseReceiptCommand`
- Added `OpenPurchaseReceiptHandler`
- Added `PurchaseReceiptController`

### Notes / Edge cases
Receipt is created with no lines and total amount equal to 0

### Checklist
- [x] I kept the change focused (no unrelated refactors)
- [ ] Tests added/updated (or N/A with reason)
- [ ] Docs updated (or N/A)
- [x] No secrets or environment-specific overrides committed
