### PR TITLE
feat(receipt): get receipt id from route when adding line

### DIFF
--- a/apps/api/Modules/Receipt/Receipt/Api/Contracts/AddLineToReceiptContract.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Contracts/AddLineToReceiptContract.cs
@@ -1,5 +1,5 @@
 ﻿namespace Receipt.Api.Contracts;
 
-public record AddLineToReceiptRequest(Guid ReceiptId, string ProductName, decimal UnitPrice, int Quantity);
+public record AddLineToReceiptRequest(string ProductName, decimal UnitPrice, int Quantity);
 
 public record AddLineToReceiptResponse(Guid ReceiptLineId);

--- a/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
@@ -22,7 +22,7 @@ public class PurchaseReceiptController(IMediator mediator) : ControllerBase
         return Created($"{response.Id}", response);
     }
 
-    [HttpPost("{receiptId: guid}/lines")]
+    [HttpPost("{receiptId:guid}/lines")]
     [ProducesResponseType(typeof(AddLineToReceiptResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<AddLineToReceiptResponse>> AddLine(

--- a/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
@@ -22,12 +22,15 @@ public class PurchaseReceiptController(IMediator mediator) : ControllerBase
         return Created($"{response.Id}", response);
     }
 
-    [HttpPost("lines")]
+    [HttpPost("{receiptId: guid}/lines")]
     [ProducesResponseType(typeof(AddLineToReceiptResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<AddLineToReceiptResponse>> AddLine([FromBody] AddLineToReceiptRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult<AddLineToReceiptResponse>> AddLine(
+        [FromRoute] Guid receiptId,
+        [FromBody] AddLineToReceiptRequest request,
+        CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new AddLineToReceiptCommand(request.ReceiptId, request.ProductName, request.UnitPrice, request.Quantity), cancellationToken);
+        var result = await mediator.Send(new AddLineToReceiptCommand(receiptId, request.ProductName, request.UnitPrice, request.Quantity), cancellationToken);
         var response = new AddLineToReceiptResponse(result.ReceiptLineId);
         return Ok(response);
     }


### PR DESCRIPTION
## Description
This PR changes the Add Line endpoint to take the receipt identifier from the route instead of the request body.

### Key changes
- Removed `ReceiptId` from request
- Changed Add Line route

### Notes / Edge cases
N/A

### Checklist
- [x] I kept the change focused (no unrelated refactors)
- [ ] Tests added/updated (or N/A with reason)
- [ ] Docs updated (or N/A)
- [x] No secrets or environment-specific overrides committed
