### PR TITLE
feat(receipt): add finalize receipt endpoint

### DIFF
--- a/apps/api/Modules/Receipt/Receipt/Api/Contracts/FinalizePurchaseReceiptContract.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Contracts/FinalizePurchaseReceiptContract.cs
@@ -1,5 +1,3 @@
 ﻿namespace Receipt.Api.Contracts;
 
-public record FinalizePurchaseReceiptRequest(Guid ReceiptId);
-
 public record FinalizePurchaseReceiptResponse(Guid ReceiptId);

--- a/apps/api/Modules/Receipt/Receipt/Api/Contracts/FinalizePurchaseReceiptContract.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Contracts/FinalizePurchaseReceiptContract.cs
@@ -1,0 +1,5 @@
+﻿namespace Receipt.Api.Contracts;
+
+public record FinalizePurchaseReceiptRequest(Guid ReceiptId);
+
+public record FinalizePurchaseReceiptResponse(Guid ReceiptId);

--- a/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
@@ -36,7 +36,7 @@ public class PurchaseReceiptController(IMediator mediator) : ControllerBase
         return Ok(response);
     }
 
-    [HttpPatch("{receiptId:guid}")]
+    [HttpPatch("{receiptId:guid}/finalize")]
     [ProducesResponseType(typeof(FinalizePurchaseReceiptResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<FinalizePurchaseReceiptResponse>> Finalize([FromRoute] Guid receiptId, CancellationToken cancellationToken)

--- a/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Receipt.Api.Contracts;
 using Receipt.Application.Features.AddLineToReceipt;
+using Receipt.Application.Features.FinalizePurchaseReceipt;
 using Receipt.Application.Features.OpenPurchaseReceipt;
 
 namespace Receipt.Api.Controllers;
@@ -29,6 +30,16 @@ public class PurchaseReceiptController(IMediator mediator) : ControllerBase
     {
         var result = await mediator.Send(new AddLineToReceiptCommand(request.ReceiptId, request.ProductName, request.UnitPrice, request.Quantity), cancellationToken);
         var response = new AddLineToReceiptResponse(result.ReceiptLineId);
+        return Ok(response);
+    }
+
+    [HttpPatch]
+    [ProducesResponseType(typeof(FinalizePurchaseReceiptResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<FinalizePurchaseReceiptResponse>> Finalize([FromBody] FinalizePurchaseReceiptRequest request, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new FinalizePurchaseReceiptCommand(request.ReceiptId), cancellationToken);
+        var response = new FinalizePurchaseReceiptResponse(result.ReceiptId);
         return Ok(response);
     }
 }

--- a/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
@@ -36,12 +36,12 @@ public class PurchaseReceiptController(IMediator mediator) : ControllerBase
         return Ok(response);
     }
 
-    [HttpPatch]
+    [HttpPatch("{receiptId:guid}")]
     [ProducesResponseType(typeof(FinalizePurchaseReceiptResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<FinalizePurchaseReceiptResponse>> Finalize([FromBody] FinalizePurchaseReceiptRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult<FinalizePurchaseReceiptResponse>> Finalize([FromRoute] Guid receiptId, CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new FinalizePurchaseReceiptCommand(request.ReceiptId), cancellationToken);
+        var result = await mediator.Send(new FinalizePurchaseReceiptCommand(receiptId), cancellationToken);
         var response = new FinalizePurchaseReceiptResponse(result.ReceiptId);
         return Ok(response);
     }

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/FinalizePurchaseReceipt/FinalizePurchaseReceiptCommand.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/FinalizePurchaseReceipt/FinalizePurchaseReceiptCommand.cs
@@ -1,0 +1,5 @@
+﻿namespace Receipt.Application.Features.FinalizePurchaseReceipt;
+
+public record FinalizePurchaseReceiptCommand(Guid ReceiptId) : ICommand<FinalizePurchaseReceiptResult>;
+
+public record FinalizePurchaseReceiptResult(Guid ReceiptId);

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/FinalizePurchaseReceipt/FinalizePurchaseReceiptHandler.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/FinalizePurchaseReceipt/FinalizePurchaseReceiptHandler.cs
@@ -1,0 +1,20 @@
+﻿using Shared.Exceptions;
+
+namespace Receipt.Application.Features.FinalizePurchaseReceipt;
+
+internal class FinalizePurchaseReceiptHandler(ReceiptDbContext dbContext) : ICommandHandler<FinalizePurchaseReceiptCommand, FinalizePurchaseReceiptResult>
+{
+    public async Task<FinalizePurchaseReceiptResult> Handle(FinalizePurchaseReceiptCommand request, CancellationToken cancellationToken)
+    {
+        var receipt = await dbContext.PurchaseReceipts
+            .Include(r => r.Lines)
+            .FirstOrDefaultAsync(r => r.Id == request.ReceiptId, cancellationToken)
+            ?? throw new NotFoundException($"Purchase receipt with ID {request.ReceiptId} not found.");
+
+        receipt.MarkAsFinalized();
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new FinalizePurchaseReceiptResult(receipt.Id);
+    }
+}

--- a/apps/api/Modules/Receipt/Receipt/ReceiptModule.cs
+++ b/apps/api/Modules/Receipt/Receipt/ReceiptModule.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Receipt.Application.Features.AddLineToReceipt;
+using Receipt.Application.Features.FinalizePurchaseReceipt;
 using Receipt.Application.Features.OpenPurchaseReceipt;
 using Shared.Data;
 using Shared.Data.Interceptors;
@@ -23,6 +24,7 @@ public static class ReceiptModule
 
         services.AddScoped<IRequestHandler<OpenPurchaseReceiptCommand, OpenPurchaseReceiptResult>, OpenPurchaseReceiptHandler>();
         services.AddScoped<IRequestHandler<AddLineToReceiptCommand, AddLineToReceiptResult>, AddLineToReceiptHandler>();
+        services.AddScoped<IRequestHandler<FinalizePurchaseReceiptCommand, FinalizePurchaseReceiptResult>, FinalizePurchaseReceiptHandler>();
 
         // Data - Infrastructure services
         var connectionString = configuration.GetConnectionString("Default");


### PR DESCRIPTION
## Description
This PR adds an endpoint to mark as finalize open receipt with at least one line through the Receipt API.

### Key changes
- Added `FinalizePurchaseReceipt` command
- Added `FinalizePurchaseReceiptHandler`
- Adder Finalize route

### Notes / Edge cases
N/A

### Checklist
- [x] I kept the change focused (no unrelated refactors)
- [ ] Tests added/updated (or N/A with reason)
- [ ] Docs updated (or N/A)
- [x] No secrets or environment-specific overrides committed
