### PR TITLE
fix(receipt): prevent impossible dates in purchase receipts

### DIFF
--- a/apps/api/Modules/Receipt/Receipt/Api/Contracts/OpenPurchaseReceiptContract.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Contracts/OpenPurchaseReceiptContract.cs
@@ -1,5 +1,5 @@
 ﻿namespace Receipt.Api.Contracts;
 
-public record OpenPurchaseReceiptRequest(DateOnly PurchaseDate, string? Location);
+public record OpenPurchaseReceiptRequest(DateOnly? PurchaseDate, string? Location);
 
 public record OpenPurchaseReceiptResponse(Guid Id);

--- a/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
+++ b/apps/api/Modules/Receipt/Receipt/Api/Controllers/PurchaseReceiptController.cs
@@ -18,7 +18,10 @@ public class PurchaseReceiptController(IMediator mediator) : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<OpenPurchaseReceiptResponse>> Create([FromBody] OpenPurchaseReceiptRequest request, CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new OpenPurchaseReceiptCommand(request.PurchaseDate, request.Location), cancellationToken);
+        if (request.PurchaseDate is null)
+            return BadRequest("Purchase date is required");
+
+        var result = await mediator.Send(new OpenPurchaseReceiptCommand(request.PurchaseDate.Value, request.Location), cancellationToken);
         var response = new OpenPurchaseReceiptResponse(result.Id);
         return Created($"{response.Id}", response);
     }

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptValidator.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptValidator.cs
@@ -11,7 +11,7 @@ internal class OpenPurchaseReceiptValidator(IClock clock) : IRequestValidator<Op
         List<ValidationFailure> failures = [];
 
         var today = DateOnly.FromDateTime(_clock.UtcNow);
-        var minimumDate = today.AddDays(-10);
+        var minimumDate = today.AddYears(-10);
 
         if (request.PurchaseDate > today)
             failures.Add(new ValidationFailure(nameof(request.PurchaseDate), "Purchase date cannot be in the future."));

--- a/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptValidator.cs
+++ b/apps/api/Modules/Receipt/Receipt/Application/Features/OpenPurchaseReceipt/OpenPurchaseReceiptValidator.cs
@@ -5,12 +5,19 @@ namespace Receipt.Application.Features.OpenPurchaseReceipt;
 internal class OpenPurchaseReceiptValidator(IClock clock) : IRequestValidator<OpenPurchaseReceiptCommand>
 {
     private readonly IClock _clock = clock;
+
     public IReadOnlyCollection<ValidationFailure> Validate(OpenPurchaseReceiptCommand request)
     {
         List<ValidationFailure> failures = [];
 
-        if (request.PurchaseDate > DateOnly.FromDateTime(_clock.UtcNow))
+        var today = DateOnly.FromDateTime(_clock.UtcNow);
+        var minimumDate = today.AddDays(-10);
+
+        if (request.PurchaseDate > today)
             failures.Add(new ValidationFailure(nameof(request.PurchaseDate), "Purchase date cannot be in the future."));
+
+        if (request.PurchaseDate < minimumDate)
+            failures.Add(new ValidationFailure(nameof(request.PurchaseDate), "Purchase date is too old."));
 
         return failures;
     }

--- a/apps/api/Modules/Receipt/Receipt/AssemblyInfo.cs
+++ b/apps/api/Modules/Receipt/Receipt/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Receipt.Tests")]

--- a/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
@@ -9,7 +9,7 @@ public class OpenPurchaseReceiptValidatorTests
     public void Validate_Returns_No_Failures_When_PurchaseDate_Is_Valid()
     {
         // Arrange
-        var clock = new FakeClock(new DateTime(2026, 4, 24, 10, 0 , 0, DateTimeKind.Utc));
+        var clock = new FakeClock(new DateTime(2026, 4, 24, 10, 0, 0, DateTimeKind.Utc));
         var validator = new OpenPurchaseReceiptValidator(clock);
 
         var request = new OpenPurchaseReceiptCommand(

--- a/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
@@ -68,10 +68,11 @@ public class OpenPurchaseReceiptValidatorTests
     {
         // Arrange
         var clock = new FakeClock(new DateTime(2026, 4, 24, 10, 0, 0, DateTimeKind.Utc));
+        var today = DateOnly.FromDateTime(clock.UtcNow);
         var validator = new OpenPurchaseReceiptValidator(clock);
 
         var request = new OpenPurchaseReceiptCommand(
-            new DateOnly(2026, 4, 24),
+            today,
             "some-location");
 
         // Act
@@ -88,10 +89,11 @@ public class OpenPurchaseReceiptValidatorTests
 
         // Arrange
         var clock = new FakeClock(new DateTime(2026, 4, 24, 10, 0, 0, DateTimeKind.Utc));
+        var today = DateOnly.FromDateTime(clock.UtcNow);
         var validator = new OpenPurchaseReceiptValidator(clock);
 
         var request = new OpenPurchaseReceiptCommand(
-            new DateOnly(2016, 4, 24),
+            today.AddYears(-10),
             "some-location");
 
         // Act

--- a/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
@@ -64,6 +64,24 @@ public class OpenPurchaseReceiptValidatorTests
     }
 
     [Fact]
+    public void Validate_Returns_No_Failures_When_PurchaseDate_Is_Today()
+    {
+        // Arrange
+        var clock = new FakeClock(new DateTime(2026, 4, 24, 10, 0, 0, DateTimeKind.Utc));
+        var validator = new OpenPurchaseReceiptValidator(clock);
+
+        var request = new OpenPurchaseReceiptCommand(
+            new DateOnly(2026, 4, 24),
+            "some-location");
+
+        // Act
+        var failures = validator.Validate(request);
+
+        // Assert
+        Assert.Empty(failures);
+    }
+
+    [Fact]
     public void Validate_Returns_No_Failures_When_PurchaseDate_Equals_MinimumDate()
     {
         // Right now minimumDate is hard coded as 10 years ago

--- a/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
@@ -43,7 +43,7 @@ public class OpenPurchaseReceiptValidatorTests
     }
 
     [Fact]
-    public void Validate_ReturnsFailure_When_PurchaseDate_Is_Too_Old()
+    public void Validate_Returns_Failure_When_PurchaseDate_Is_Too_Old()
     {
         // Right now too old is hard coded as older than 10 years
 

--- a/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
@@ -22,4 +22,64 @@ public class OpenPurchaseReceiptValidatorTests
         // Assert
         Assert.Empty(failures);
     }
+
+    [Fact]
+    public void Validate_Returns_Failure_When_PurchaseDate_Is_In_The_Future()
+    {
+        // Arrange
+        var clock = new FakeClock(new DateTime(2026, 4, 24, 10, 0, 0, DateTimeKind.Utc));
+        var validator = new OpenPurchaseReceiptValidator(clock);
+
+        var request = new OpenPurchaseReceiptCommand(
+            new DateOnly(2026, 8, 30),
+            "some-location");
+
+        // Act
+        var failures = validator.Validate(request);
+
+        // Assert
+        Assert.Single(failures);
+        Assert.Equal(nameof(OpenPurchaseReceiptCommand.PurchaseDate), failures.First().Property);
+    }
+
+    [Fact]
+    public void Validate_ReturnsFailure_When_PurchaseDate_Is_Too_Old()
+    {
+        // Right now too old is hard coded as older than 10 years
+
+        // Arrange
+        var clock = new FakeClock(new DateTime(2026, 4, 24, 10, 0, 0, DateTimeKind.Utc));
+        var validator = new OpenPurchaseReceiptValidator(clock);
+
+        var request = new OpenPurchaseReceiptCommand(
+            new DateOnly(2000, 4, 24),
+            "some-location");
+
+        // Act
+        var failures = validator.Validate(request);
+
+        // Assert
+        Assert.Single(failures);
+        Assert.Equal(nameof(OpenPurchaseReceiptCommand.PurchaseDate), failures.First().Property);
+    }
+
+    [Fact]
+    public void Validate_Returns_No_Failures_When_PurchaseDate_Equals_MinimumDate()
+    {
+        // Right now minimumDate is hard coded as 10 years ago
+
+        // Arrange
+        var clock = new FakeClock(new DateTime(2026, 4, 24, 10, 0, 0, DateTimeKind.Utc));
+        var validator = new OpenPurchaseReceiptValidator(clock);
+
+        var request = new OpenPurchaseReceiptCommand(
+            new DateOnly(2016, 4, 24),
+            "some-location");
+
+        // Act
+        var failures = validator.Validate(request);
+
+        // Assert
+        Assert.Empty(failures);
+    }
 }

--- a/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Application/OpenPurchaseReceiptValidatorTests.cs
@@ -1,0 +1,25 @@
+﻿using Receipt.Application.Features.OpenPurchaseReceipt;
+using Receipt.Tests.TestHelpers;
+
+namespace Receipt.Tests.Application;
+
+public class OpenPurchaseReceiptValidatorTests
+{
+    [Fact]
+    public void Validate_Returns_No_Failures_When_PurchaseDate_Is_Valid()
+    {
+        // Arrange
+        var clock = new FakeClock(new DateTime(2026, 4, 24, 10, 0 , 0, DateTimeKind.Utc));
+        var validator = new OpenPurchaseReceiptValidator(clock);
+
+        var request = new OpenPurchaseReceiptCommand(
+            new DateOnly(2026, 4, 20),
+            "some-location");
+
+        // Act
+        var failures = validator.Validate(request);
+
+        // Assert
+        Assert.Empty(failures);
+    }
+}

--- a/apps/api/Tests/Receipt/Receipt.Tests/Domain/PurchaseReceiptTests.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Domain/PurchaseReceiptTests.cs
@@ -1,6 +1,7 @@
 ﻿using Receipt.Domain.Models;
+using Receipt.Tests.TestHelpers;
 
-namespace Receipt.Tests;
+namespace Receipt.Tests.Domain;
 
 public class PurchaseReceiptTests
 {

--- a/apps/api/Tests/Receipt/Receipt.Tests/Domain/ReceiptLineTests.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Domain/ReceiptLineTests.cs
@@ -1,8 +1,8 @@
 ﻿using Receipt.Domain.Models;
 
-namespace Receipt.Tests;
+namespace Receipt.Tests.Domain;
 
-public class ReceiptLineCreationTests
+public class ReceiptLineTests
 {
     [Fact]
     public void Create_Sets_All_Properties_Correctly()

--- a/apps/api/Tests/Receipt/Receipt.Tests/Receipt.Tests.csproj
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Receipt.Tests.csproj
@@ -22,8 +22,4 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Application\" />
-  </ItemGroup>
-
 </Project>

--- a/apps/api/Tests/Receipt/Receipt.Tests/Receipt.Tests.csproj
+++ b/apps/api/Tests/Receipt/Receipt.Tests/Receipt.Tests.csproj
@@ -22,4 +22,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Application\" />
+  </ItemGroup>
+
 </Project>

--- a/apps/api/Tests/Receipt/Receipt.Tests/TestHelpers/FakeClock.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/TestHelpers/FakeClock.cs
@@ -1,0 +1,8 @@
+﻿using Shared.Abstractions.Time;
+
+namespace Receipt.Tests.TestHelpers;
+
+public class FakeClock(DateTime utcNow) : IClock
+{
+    public DateTime UtcNow { get; set; } = utcNow;
+}

--- a/apps/api/Tests/Receipt/Receipt.Tests/TestHelpers/ReceiptTestFactory.cs
+++ b/apps/api/Tests/Receipt/Receipt.Tests/TestHelpers/ReceiptTestFactory.cs
@@ -1,6 +1,6 @@
 ﻿using Receipt.Domain.Models;
 
-namespace Receipt.Tests;
+namespace Receipt.Tests.TestHelpers;
 
 public static class ReceiptTestFactory
 {


### PR DESCRIPTION
## Description
This PR fixes the problem with `PurchaseReceip` sometimes being saved with impossible date.

### Key changes
- Made `PurchaseDate` nullable in Contract
- Added validator checks
- Added validator tests

### Notes / Edge cases
N/A

### Checklist
- [x] I kept the change focused (no unrelated refactors)
- [x] Tests added/updated (or N/A with reason)
- [ ] Docs updated (or N/A)
- [x] No secrets or environment-specific overrides committed
