### PR TITLE
fix(dependabot): correct the typo in configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
    open-pull-requests-limit: 3
    labels:
     - "CI"
-   reviewrs:
+   reviewers:
     - "NikolaDmitrasinovic"
    commit-message:
     prefix: "ci(dependabot)"
@@ -29,7 +29,7 @@ updates:
    open-pull-requests-limit: 2
    labels:
     - "CI"
-   reviewrs:
+   reviewers:
     - "NikolaDmitrasinovic"
    commit-message:
     prefix: "ci(dependabot)"


### PR DESCRIPTION
## Description
This PR fixes the typo in the Dependabot configuration file

### Key changes
- change 'reviewrs' to 'reviewers' 

### Notes / Edge cases
N/A

### Checklist
- [x] I kept the change focused (no unrelated refactors)
- [ ] Tests added/updated (or N/A with reason)
- [ ] Docs updated (or N/A)
- [x] No secrets or environment-specific overrides committed
