### PR TITLE
ci(dependabot): remove reviewers tag

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,8 +8,6 @@ updates:
    open-pull-requests-limit: 3
    labels:
     - "CI"
-   reviewers:
-    - "NikolaDmitrasinovic"
    commit-message:
     prefix: "ci(dependabot)"
    pull-request-branch-name:
@@ -29,8 +27,6 @@ updates:
    open-pull-requests-limit: 2
    labels:
     - "CI"
-   reviewers:
-    - "NikolaDmitrasinovic"
    commit-message:
     prefix: "ci(dependabot)"
    pull-request-branch-name:


### PR DESCRIPTION
## Description
This PR removes the deprecated `reviewers` tag from the Dependabot configuration file.

### Key changes
- Updated `dependabot.yaml`

### Notes / Edge cases
Reviewers tag was used to auto-set the reviewer when Dependabot is opening the new PR, but the feature is now deprecated. CODEOWNERS is now used automatically, we will consider adding it when we need it it's actual purpose, not before.

### Checklist
- [x] I kept the change focused (no unrelated refactors)
- [ ] Tests added/updated (or N/A with reason)
- [ ] Docs updated (or N/A)
- [x] No secrets or environment-specific overrides committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->